### PR TITLE
Add destination GUID filter example

### DIFF
--- a/examples/c++11/autopilot.cxx
+++ b/examples/c++11/autopilot.cxx
@@ -42,6 +42,10 @@ void run(ApplicationArguments args)
         healthreport_writer.write(sample);
         // std::cout << "Sending Health Report/Waiting for data\n";
 
+        std::cout << "\n\n____________________________________________________________________\n"
+                  << "Telemetry Reports:\n"
+                  << "____________________________________________________________________\n";
+
         // Optional, so check first
         if (ap.speed_report_data().speedThroughWater().has_value()) {
             auto current_speed =
@@ -66,43 +70,53 @@ void run(ApplicationArguments args)
         // This is just a reference on accessing values in Type
         if (!ap.global_vector_commands().empty())
         {
-            std::cout << "Current Global Vector Commands:\n";
+          std::cout << "\n\n____________________________________________________________________\n"
+                    << "Global Vector Commands:\n"
+                    << "____________________________________________________________________\n";
 
-            for (auto& it : ap.global_vector_commands()) {
-                std::cout << "Speed Command " 
-                          << it.second.data().speed().SpeedRequirementVariantTypeSubtypes().WaterSpeedRequirementVariantVariant().speed().speed()
-                          << " State: "
-                          << it.second.info().state().instance_state()
-                          << std::endl;
-            }
+          for (auto &it : ap.global_vector_commands())
+          {
+            std::cout << "--------------------------------------------------------------------" << std::endl;
+            std::cout << "Instance Handle: " << it.second.info().instance_handle() << std::endl;
+            std::cout << "State: " << it.second.info().state().instance_state() << std::endl;
 
-            /**
-             * Convert InstanceHandle back to individual values
-             * This is for the use case when you receive a command and need to update the 
-             * corresponding CommandStatus using the SessionID with the current state
-             **/ 
-            auto instance_handle = ap.global_vector_commands().begin()->first;
-            GlobalVectorCommandType key_holder;
-
-            ap.global_vector_cmd_reader().key_value(key_holder, instance_handle);
-
-            // Print Session ID
-            auto session_id = key_holder.sessionID();
-            std::cout << "Session ID: ";
-            for (const auto &byte : session_id)
+            if (it.second.info().state().instance_state() == InstanceState::alive())
             {
-              printf("%02x ", byte);
-            }
-            std::cout << std::endl;
 
-            // Print Destination ID
-            auto dest_id = key_holder.destination().parentID();
-            std::cout << "Destination ID: ";
-            for (const auto &byte : dest_id)
-            {
-              printf("%02x ", byte);
+              std::cout << "Current Water Speed Command: " << it.second.data().speed().SpeedRequirementVariantTypeSubtypes().WaterSpeedRequirementVariantVariant().speed().speed() << std::endl;
+
+              /**
+               * Convert InstanceHandle back to individual values
+               * This is for the use case when you receive a command and need to update the
+               * corresponding CommandStatus using the SessionID with the current state
+               **/
+              auto instance_handle = ap.global_vector_commands().begin()->first;
+              GlobalVectorCommandType key_holder;
+
+              ap.global_vector_cmd_reader().key_value(key_holder, instance_handle);
+
+              // Print Session ID
+              auto session_id = key_holder.sessionID();
+              std::cout << "Session ID: ";
+              for (const auto &byte : session_id)
+              {
+                printf("%02x ", byte);
+              }
+              std::cout << std::endl;
+
+              // Print Destination ID
+              auto dest_id = key_holder.destination().parentID();
+              std::cout << "Destination ID: ";
+              for (const auto &byte : dest_id)
+              {
+                printf("%02x ", byte);
+              }
+              std::cout << std::endl;
+            } 
+
             }
-            std::cout << std::endl;
+
+            
         }
 
         rti::util::sleep(Duration(1));

--- a/examples/c++11/autopilot.cxx
+++ b/examples/c++11/autopilot.cxx
@@ -86,11 +86,21 @@ void run(ApplicationArguments args)
 
             ap.global_vector_cmd_reader().key_value(key_holder, instance_handle);
 
-            auto id = key_holder.sessionID();
+            // Print Session ID
+            auto session_id = key_holder.sessionID();
             std::cout << "Session ID: ";
-            for (const auto &byte : id)
+            for (const auto &byte : session_id)
             {
-              std::cout << static_cast<int>(byte) << " ";
+              printf("%02x ", byte);
+            }
+            std::cout << std::endl;
+
+            // Print Destination ID
+            auto dest_id = key_holder.destination().parentID();
+            std::cout << "Destination ID: ";
+            for (const auto &byte : dest_id)
+            {
+              printf("%02x ", byte);
             }
             std::cout << std::endl;
         }
@@ -114,7 +124,7 @@ int main(int argc, char *argv[])
     rti::config::Logger::instance().verbosity(arguments.verbosity);
 
     //Set the debug output to a specific file
-    // rti::config::Logger::instance().output_file("debug_output.log");
+    rti::config::Logger::instance().output_file("debug_output.log");
 
     // Log a debug message to verify - Needs to be at Level 5 Verbosity
     rti::config::Logger::instance().debug("This is a debug message logged to the file.");

--- a/examples/py/umaa_globalvectorcmd.py
+++ b/examples/py/umaa_globalvectorcmd.py
@@ -59,7 +59,7 @@ def publisher_main():
     globalvector_command_sample = UMAA_MO_GlobalVectorControl_GlobalVectorCommandType()
 
     # Select the union to send
-    speed_cmd = random.randrange(0, 10, 2)
+    speed_cmd = random.randrange(2, 10, 2)
     globalvector_command_sample.speed.SpeedRequirementVariantTypeSubtypes.discriminator = \
             UMAA_Common_Speed_SpeedRequirementVariantTypeEnum.WATERSPEEDREQUIREMENTVARIANT_D
 
@@ -71,6 +71,12 @@ def publisher_main():
     sessionid_guid = uuid.uuid4()
     sessionid_guid_list = list(sessionid_guid.bytes)
     globalvector_command_sample.sessionID.value = dds.Uint8Seq(sessionid_guid_list)
+
+    # Set a Destination GUID for the AutoPilot Component
+    dest_guid = uuid.UUID(str("cb8e8858-c8c2-277f-94b6-32287bed9d05"))
+    dest_guid_list = list(dest_guid.bytes)
+
+    globalvector_command_sample.destination.parentID.value = dds.Uint8Seq(dest_guid_list)
 
 
     # write data samples in a loop

--- a/examples/py/umaa_globalvectorcmd.py
+++ b/examples/py/umaa_globalvectorcmd.py
@@ -78,6 +78,7 @@ def publisher_main():
 
     globalvector_command_sample.destination.parentID.value = dds.Uint8Seq(dest_guid_list)
 
+    cmds_sent = 0
 
     # write data samples in a loop
     while (True):
@@ -85,6 +86,14 @@ def publisher_main():
 
         globalvector_command_w.write(globalvector_command_sample)
         print(f'Writing Global Vector Command (Speed): {speed_cmd }')
+        cmds_sent += 1
+
+        if cmds_sent == 5:
+          print("Sent 5 commands, Cancelling (disposing) Command...")
+          instance_handle = globalvector_command_w.lookup_instance(
+              globalvector_command_sample)
+          globalvector_command_w.dispose_instance(instance_handle)
+          break
 
 
 if __name__ == "__main__":

--- a/resources/components/umaa_autopilot.xml
+++ b/resources/components/umaa_autopilot.xml
@@ -25,7 +25,16 @@ to use the software.
         <element>
             <name>DOMAIN_ID</name>
             <value>1</value>
-        </element> 
+        </element>
+        <element>
+          <!-- 
+            Need to remove dashes from GUID for the content filter to work. 
+            Can add spaces to the GUID to make it more readable.
+            -->
+          <name>GUID</name>
+          <value>cb 8e 88 58 c8 c2 27 7f 94 b6 32 28 7b ed 9d 05</value>
+
+        </element>
     </configuration_variables>
 
     <!-- Participant library -->
@@ -142,7 +151,16 @@ to use the software.
                 <!-- GlobalVectorControl Service (Producer) -->
                 <data_reader name="GlobalVectorCommandType"
                     topic_ref="UMAA::MO::GlobalVectorControl::GlobalVectorCommandType">
-                    <datareader_qos base_name="umaa_qos_lib::topic_qos_assign" />
+                  <datareader_qos base_name="umaa_qos_lib::topic_qos_assign" />
+
+                  <!-- 
+                    Create Content Filter to filter out messages that are not for this autopilot instance. 
+                    Make sure you define "kind" or it will fail silently (CORE-10554).
+                    -->
+                  <content_filter kind="builtin.sql">
+                    <expression>destination.parentID = &amp;hex($(GUID))</expression>
+                  </content_filter>
+
                 </data_reader>
 
                 <!-- GlobalHoverControl Service (Producer) -->


### PR DESCRIPTION
- Populate destination.ParentID in GlobalVectorCommand Service
- Add XML configuration to filter by destination.ParentID
- Add printouts for Destination ID
- Add example to cancel/dispose command
- Add printouts for multiple Instances